### PR TITLE
Update pgmspace include for SAMD and SAM

### DIFF
--- a/src/Base64.cpp
+++ b/src/Base64.cpp
@@ -8,7 +8,7 @@ This library is distributed in the hope that it will be useful, but WITHOUT ANY 
 
 #include "Base64.h"
 #include <Arduino.h>
-#if (defined(__AVR__))
+#if (defined(__AVR__) || defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_SAM))
 #include <avr/pgmspace.h>
 #else
 #include <pgmspace.h>


### PR DESCRIPTION
For both cores the pgmspace.h lives in the avr subdirectory. I don't know for which one the header lives in the root, however some (megaavr and mbed) do not have this file completely. But I don't simply want to remove it. May be better to define it as an empty macro if it doesn't exist yet.